### PR TITLE
support existing config directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,14 @@
 # The dir under which setup-ds-admin.pl .inf files will be created and stored. Default: '/var/lib/dirsrv/setup'.
 # Note that /var/lib/dirsrv/ is created by the 389-ds-base package.
 #
+# [use_existing_mc]
+# Boolean. Sets whether to store the configuration data
+# in a separate Configuration Directory Server. Valid values are 0 or 1.
+# default: false, Meaning the configuration data are stored in this new instance.
+#
+# [slapd_config_for_mc]
+# Boolean. Sets whether to store the configuration data in the new Directory Server instance.
+# default: true, Meaning the configuration data are stored in this new instance.
 # <Document other parameters>
 #
 # === Examples
@@ -56,6 +64,8 @@ class port389(
   $ssl_cert                   = $::port389::params::ssl_cert,
   $ssl_key                    = $::port389::params::ssl_key,
   $ssl_ca_certs               = $::port389::params::ssl_ca_certs,
+  $slapd_config_for_mc        = $::port389::params::slapd_config_for_mc,
+  $use_existing_mc            = $::port389::params::use_existing_mc,
 ) inherits port389::params {
   validate_re($ensure, '^present$|^absent$|^latest$|^purged$')
   if !(is_string($package_ensure) or is_array($package_ensure)) {

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,4 +1,13 @@
 # port389::instance
+# [use_existing_mc]
+# Boolean. Sets whether to store the configuration data
+# in a separate Configuration Directory Server. Valid values are 0 or 1.
+# default: false, Meaning the configuration data are stored in this new instance.
+#
+# [slapd_config_for_mc]
+# Boolean. Sets whether to store the configuration data in the new Directory Server instance.
+# default: true, Meaning the configuration data are stored in this new instance.
+
 define port389::instance (
   $admin_domain               = $::port389::admin_domain,
   $config_directory_admin_id  = $::port389::config_directory_admin_id,
@@ -13,6 +22,8 @@ define port389::instance (
   $ssl_key                    = $::port389::ssl_key,
   $ssl_ca_certs               = $::port389::ssl_ca_certs,
   $schema_file                = undef,
+  $slapd_config_for_mc        = 'yes',
+  $use_existing_mc            = '0',
   $suffix                     = port389_domain2dn($::port389::admin_domain),
 ) {
   # follow the same server identifier validation rules as setup-ds-admin.pl
@@ -35,6 +46,9 @@ define port389::instance (
   }
   # schema_file may be undef
   validate_string($suffix)
+  #configuration directory
+  validate_re($slapd_config_for_mc,['yes','no'], "${slapd_config_for_mc} is invalid for slapd_config_for_mc. Must be set to yes or no")
+  validate_re($use_existing_mc,['0','1'],"${use_existing_mc} is invalid for use_existing_mc. Must be set to 0 or 1.")
 
   $setup_inf_name = "setup_${title}.inf"
   $setup_inf_path = "${::port389::setup_dir}/${setup_inf_name}"
@@ -69,9 +83,9 @@ define port389::instance (
       'SchemaFile'       => $schema_file,
       'ServerIdentifier' => $title,
       'ServerPort'       => $server_port,
-      'SlapdConfigForMC' => 'yes',
+      'SlapdConfigForMC' => $slapd_config_for_mc,
       'Suffix'           => $suffix,
-      'UseExistingMC'    => '0',
+      'UseExistingMC'    => $use_existing_mc,
       'ds_bename'        => 'userRoot',
       #'bak_dir' => '/var/lib/dirsrv/slapd-ldap1/bak',
       #'bindir' => '/usr/bin',

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,13 +1,4 @@
 # port389::instance
-# [use_existing_mc]
-# Boolean. Sets whether to store the configuration data
-# in a separate Configuration Directory Server. Valid values are 0 or 1.
-# default: false, Meaning the configuration data are stored in this new instance.
-#
-# [slapd_config_for_mc]
-# Boolean. Sets whether to store the configuration data in the new Directory Server instance.
-# default: true, Meaning the configuration data are stored in this new instance.
-
 define port389::instance (
   $admin_domain               = $::port389::admin_domain,
   $config_directory_admin_id  = $::port389::config_directory_admin_id,
@@ -22,8 +13,8 @@ define port389::instance (
   $ssl_key                    = $::port389::ssl_key,
   $ssl_ca_certs               = $::port389::ssl_ca_certs,
   $schema_file                = undef,
-  $slapd_config_for_mc        = 'yes',
-  $use_existing_mc            = '0',
+  $slapd_config_for_mc        = $::port389::slapd_config_for_mc,
+  $use_existing_mc            = $::port389::use_existing_mc,
   $suffix                     = port389_domain2dn($::port389::admin_domain),
 ) {
   # follow the same server identifier validation rules as setup-ds-admin.pl
@@ -112,13 +103,13 @@ define port389::instance (
     'present', 'latest': {
       # disable bucketting since the .inf file contains password information
       file { $setup_inf_name:
-        ensure  => file,
-        path    => $setup_inf_path,
-        owner   => $::port389::user,
-        group   => $::port389::group,
-        mode    => '0600',
-        content => template("${module_name}/inf.erb"),
-        backup  => false,
+        ensure    => file,
+        path      => $setup_inf_path,
+        owner     => $::port389::user,
+        group     => $::port389::group,
+        mode      => '0600',
+        content   => template("${module_name}/inf.erb"),
+        backup    => false,
         show_diff => false
       } ->
       # /usr/sbin/setup-ds-admin.pl needs:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,9 +53,11 @@ class port389::params {
   $server_ipaddress  = '0.0.0.0'
 
   # slapd section defaults
-  $root_dn     = 'cn=Directory Manager'
-  $root_dn_pwd = 'password'
-  $server_port = '389'
+  $root_dn             = 'cn=Directory Manager'
+  $root_dn_pwd         = 'password'
+  $server_port         = '389'
+  $use_existing_mc     = 0
+  $slapd_config_for_mc = 'yes'
 
   # the dir under which setup-ds-admin.pl .inf files will be created and stored
   # note that /var/lib/dirsrv/ is created by the 389-ds-base package


### PR DESCRIPTION
still defaults to local config directory for standalone deploys
